### PR TITLE
feat(windows): add Launch4j config & docs for Windows exe (no PII)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+dist/
+launch4j*.zip
+*.lnk

--- a/launch4j-config.xml
+++ b/launch4j-config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch4jConfig>
+  <dontWrapJar>false</dontWrapJar>
+  <headerType>console</headerType>
+  <outfile>dist\PokerHandApp.exe</outfile>
+  <jar>target\poker-hand-app-1.0-SNAPSHOT.jar</jar>
+  <errTitle>Poker Hand App</errTitle>
+  <cmdLine></cmdLine>
+  <chdir>.</chdir>
+  <priority>normal</priority>
+  <downloadUrl>https://adoptium.net/</downloadUrl>
+  <supportUrl>https://github.com/OWNER/REPO</supportUrl>
+  <stayAlive>false</stayAlive>
+  <manifest></manifest>
+  <icon></icon>
+  <classPath>
+    <mainClass>poker.PokerHandApp</mainClass>
+  </classPath>
+  <jre>
+    <path></path>
+    <minVersion>17</minVersion>
+    <maxVersion></maxVersion>
+    <jdkPreference>preferJre</jdkPreference>
+    <runtimeBits>64/32</runtimeBits>
+  </jre>
+</launch4jConfig>

--- a/scripts/windows/PokerHandApp-run.cmd
+++ b/scripts/windows/PokerHandApp-run.cmd
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+cd /d "%~dp0..\..\dist"
+echo Enter 5 cards (e.g. AS KS QS JS 10S):
+set /p CARDS=
+"%cd%\PokerHandApp.exe" %CARDS%
+echo.
+pause
+endlocal


### PR DESCRIPTION
## Summary
- add Launch4j configuration that uses console header defaults, relative paths, and an explicit main class for poker.PokerHandApp
- provide a Windows launcher batch script for double-click execution with interactive input
- document the Windows exe build workflow, troubleshooting, and security notes while keeping paths relative and owner placeholders intact
- ignore dist outputs, Launch4j download archives, and shortcut files

## Testing
- ⚠️ `mvn -q clean package` *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d04259c83228602d27c390fedf0